### PR TITLE
improve: support value none in attribute

### DIFF
--- a/next_cvat/types/attribute.py
+++ b/next_cvat/types/attribute.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Optional
+
 from pydantic import BaseModel
 
 
 class Attribute(BaseModel):
     name: str
-    value: str
+    value: Optional[str]


### PR DESCRIPTION
Apparently this can be `None` some times, idk if it makes more sense to convert it to empty string or just allow `None`?

```
│ /home/aiwizo/Documents/trafikverket-rail-damage/.venv/lib/python3.10/site-packages/next_cvat/annotations.py:91 in <listcomp>                                                                                                                               │
│                                                                                                                                                                                                                                                            │
│    88 │   │   │   masks = []                                                                                                                                                                                                                               │
│    89 │   │   │   for mask in image.findall("mask"):                                                                                                                                                                                                       │
│    90 │   │   │   │   mask_attributes = [                                                                                                                                                                                                                  │
│ ❱  91 │   │   │   │   │   Attribute(name=attr.get("name"), value=attr.text)                                                                                                                                                                                │
│    92 │   │   │   │   │   for attr in mask.findall("attribute")                                                                                                                                                                                            │
│    93 │   │   │   │   ]                                                                                                                                                                                                                                    │
│    94 │   │   │   │   masks.append(Mask(**mask.attrib, attributes=mask_attributes))                                                                                                                                                                        │
│                                                                                                                                                                                                                                                            │
│ /home/aiwizo/Documents/trafikverket-rail-damage/.venv/lib/python3.10/site-packages/pydantic/main.py:214 in __init__                                                                                                                                        │
│                                                                                                                                                                                                                                                            │
│    211 │   │   """                                                                                                                                                                                                                                         │
│    212 │   │   # `__tracebackhide__` tells pytest and some other tools to omit this function fr                                                                                                                                                            │
│    213 │   │   __tracebackhide__ = True                                                                                                                                                                                                                    │
│ ❱  214 │   │   validated_self = self.__pydantic_validator__.validate_python(data, self_instance                                                                                                                                                            │
│    215 │   │   if self is not validated_self:                                                                                                                                                                                                              │
│    216 │   │   │   warnings.warn(                                                                                                                                                                                                                          │
│    217 │   │   │   │   'A custom validator is returning a value other than `self`.\n'                                                                                                                                                                      │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
ValidationError: 1 validation error for Attribute              
value                                                          
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]                           
    For further information visit https://errors.pydantic.dev/2.10/v/string_type  
```